### PR TITLE
Cleanup codebase.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,92 @@
-*.py[cod]
-
-*.egg
-*.egg-info
-dist
-build
-sdist
-
-.coverage
-.vscode/
-.idea/
-htmlcov/
-
-.DS_STORE
-
-_ignored/
+# Byte-compiled / optimized / DLL files
 __pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# Mypy cache
+.mypy_cache/

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,12 @@ clean:
 	rm -rf pangu.egg-info/
 
 debug:
-	python setup.py develop
+	pip install --editable .
 
-publish:
-	python setup.py publish
+pkg: clean
+	pip install wheel -U
+	python setup.py bdist_wheel sdist
+
+publish: pkg
+	pip install twine -U
+	twine upload dist/*

--- a/README.rst
+++ b/README.rst
@@ -8,10 +8,10 @@ pangu.py
     :target: https://codecov.io/github/vinta/pangu.py
 
 .. image:: https://img.shields.io/pypi/v/pangu.svg?style=flat-square
-    :target: https://pypi.python.org/pypi/pangu
+    :target: https://pypi.org/project/pangu/
 
 .. image:: https://img.shields.io/pypi/pyversions/pangu.svg?style=flat-square
-    :target: https://pypi.python.org/pypi/pangu
+    :target: https://pypi.org/project/pangu/
 
 .. image:: https://img.shields.io/badge/made%20with-%e2%9d%a4-ff69b4.svg?style=flat-square
     :target: https://vinta.ws/code/

--- a/bin/pangu
+++ b/bin/pangu
@@ -1,9 +1,0 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
-
-from pangu import PanguCLI
-
-
-if __name__ == '__main__':
-    PanguCLI().parse()

--- a/pangu.py
+++ b/pangu.py
@@ -58,40 +58,36 @@ def spacing_text(text):
     """
     Perform paranoid text spacing on text.
     """
-    new_text = text
-
     # always use unicode
-    if IS_PY2 and isinstance(new_text, str):
-        new_text = new_text.decode('utf-8')
+    if IS_PY2 and isinstance(text, str):
+        text = text.decode('utf-8')
 
-    if len(new_text) < 2:
-        return new_text
+    if len(text) < 2:
+        return text
 
-    new_text = CJK_QUOTE_RE.sub(r'\1 \2', new_text)
-    new_text = QUOTE_CJK_RE.sub(r'\1 \2', new_text)
-    new_text = FIX_QUOTE_RE.sub(r'\1\3\5', new_text)
-    new_text = FIX_SINGLE_QUOTE_RE.sub(r'\1\3\4', new_text)
+    text = CJK_QUOTE_RE.sub(r'\1 \2', text)
+    text = QUOTE_CJK_RE.sub(r'\1 \2', text)
+    text = FIX_QUOTE_RE.sub(r'\1\3\5', text)
+    text = FIX_SINGLE_QUOTE_RE.sub(r'\1\3\4', text)
 
-    new_text = CJK_HASH_RE.sub(r'\1 \2', new_text)
-    new_text = HASH_CJK_RE.sub(r'\1 \3', new_text)
+    text = CJK_HASH_RE.sub(r'\1 \2', text)
+    text = HASH_CJK_RE.sub(r'\1 \3', text)
 
-    new_text = CJK_OPERATOR_ANS_RE.sub(r'\1 \2 \3', new_text)
-    new_text = ANS_OPERATOR_CJK_RE.sub(r'\1 \2 \3', new_text)
+    text = CJK_OPERATOR_ANS_RE.sub(r'\1 \2 \3', text)
+    text = ANS_OPERATOR_CJK_RE.sub(r'\1 \2 \3', text)
 
-    old_text = new_text
-    tmp_text = CJK_BRACKET_CJK_RE.sub(r'\1 \2 \4', new_text)
-    new_text = tmp_text
-    if old_text == tmp_text:
-        new_text = CJK_BRACKET_RE.sub(r'\1 \2', new_text)
-        new_text = BRACKET_CJK_RE.sub(r'\1 \2', new_text)
-    new_text = FIX_BRACKET_RE.sub(r'\1\3\5', new_text)
+    old_text, text = text, CJK_BRACKET_CJK_RE.sub(r'\1 \2 \4', text)
+    if old_text == text:
+        text = CJK_BRACKET_RE.sub(r'\1 \2', text)
+        text = BRACKET_CJK_RE.sub(r'\1 \2', text)
+    text = FIX_BRACKET_RE.sub(r'\1\3\5', text)
 
-    new_text = FIX_SYMBOL_RE.sub(r'\1\2 \3', new_text)
+    text = FIX_SYMBOL_RE.sub(r'\1\2 \3', text)
 
-    new_text = CJK_ANS_RE.sub(r'\1 \2', new_text)
-    new_text = ANS_CJK_RE.sub(r'\1 \2', new_text)
+    text = CJK_ANS_RE.sub(r'\1 \2', text)
+    text = ANS_CJK_RE.sub(r'\1 \2', text)
 
-    return new_text.strip()
+    return text.strip()
 
 
 def spacing_file(path):
@@ -99,8 +95,7 @@ def spacing_file(path):
     Perform paranoid text spacing from file.
     """
     with open(os.path.abspath(path)) as f:
-        fdata = f.read()
-    return spacing_text(fdata)
+        return spacing_text(f.read())
 
 
 def spacing(text_or_path):
@@ -108,10 +103,9 @@ def spacing(text_or_path):
     Perform paranoid text spacing, might cause ambiguous results.
     """
     if os.path.isfile(os.path.abspath(text_or_path)):
-        new_text = spacing_file(text_or_path)
+        return spacing_file(text_or_path)
     else:
-        new_text = spacing_text(text_or_path)
-    return new_text
+        return spacing_text(text_or_path)
 
 
 def main(args=sys.argv[1:]):

--- a/pangu.py
+++ b/pangu.py
@@ -21,7 +21,7 @@ import sys
 
 
 __version__ = '3.3.0.1'
-__all__ = ['spacing_text', 'spacing_file', 'spacing', 'PanguCLI']
+__all__ = ['spacing_text', 'spacing_file', 'spacing', 'main']
 
 IS_PY2 = (sys.version_info[0] == 2)
 
@@ -114,29 +114,31 @@ def spacing(text_or_path):
     return new_text
 
 
-class PanguCLI(object):
+def main(args=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        prog='pangu',
+        description='Paranoid text spacing for good readability, '
+                    'to automatically insert whitespace between '
+                    'CJK and half-width characters.',
+    )
+    parser.add_argument(
+        '-v', '--version', action='version', version=__version__)
+    parser.add_argument(
+        '-f', '--file', action='store_true', dest='is_file', required=False,
+        help='specify whether input value is text or file path')
+    parser.add_argument(
+        'target', action='store', type=str,
+        help='text or file path to perform spacing')
 
-    def __init__(self):
-        self.parser = argparse.ArgumentParser(
-            prog='pangu',
-            description='Paranoid text spacing for good readability, to automatically insert whitespace between CJK and half-width characters.',
-        )
-        self.parser.add_argument('-v', '--version', action='version', version=__version__)
-        self.parser.add_argument('-f', '--file', action='store_true', dest='is_file', required=False, help='specify whether input value is text or file path')
-        self.parser.add_argument('text_or_path', action='store', type=str, help='text or file path to perform spacing')
-
-    def parse(self):
-        if not sys.stdin.isatty():
-            print(spacing_text(sys.stdin.read()))  # noqa: T003
-        elif len(sys.argv) > 1:
-            args = self.parser.parse_args()
-            if args.is_file:
-                print(spacing_file(args.text_or_path))  # noqa: T003
-            else:
-                print(spacing_text(args.text_or_path))  # noqa: T003
+    if not sys.stdin.isatty():
+        print(spacing_text(sys.stdin.read()))  # noqa: T003
+    else:
+        args = parser.parse_args(args)
+        if args.is_file:
+            print(spacing_file(args.target))  # noqa: T003
         else:
-            self.parser.print_help()
+            print(spacing_text(args.target))  # noqa: T003
 
 
 if __name__ == '__main__':
-    PanguCLI().parse()
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,5 @@
 [bdist_wheel]
 universal = 1
 
-[wheel]
-universal = 1
-
 [metadata]
 license-file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -3,22 +3,18 @@
 
 import os
 import sys
+import re
 
 from setuptools import setup
 
+_VERSION_RE = re.compile(r"__version__\s*?=\s*?'(.*?)'", flags=re.M)
+
 
 def get_version():
-    code = None
     path = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)),
-        'pangu.py',
-    )
+        os.path.dirname(os.path.abspath(__file__)), 'pangu.py')
     with open(path) as f:
-        for line in f:
-            if line.startswith('__version__'):
-                code = line[len('__version__ = '):]
-                break
-    return eval(code)
+        return _VERSION_RE.findall(f.read())[-1]
 
 
 if sys.argv[-1] == 'wheel':
@@ -33,8 +29,6 @@ if sys.argv[-1] == 'publish':
     os.system('twine upload dist/*')
     sys.exit(0)
 
-long_description = open('README.rst').read() + '\n' + open('HISTORY.rst').read()
-
 setup(
     name='pangu',
     version=get_version(),
@@ -42,7 +36,8 @@ setup(
                 'to automatically insert whitespace between CJK '
                 '(Chinese, Japanese, Korean) and half-width characters '
                 '(alphabetical letters, numerical digits and symbols).',
-    long_description=long_description,
+    long_description=open(
+        'README.rst').read() + '\n' + open('HISTORY.rst').read(),
     keywords='pangu space white text spacing readability',
     author='Vinta Chen',
     author_email='vinta.chen@gmail.com',
@@ -51,7 +46,7 @@ setup(
     include_package_data=True,
     py_modules=['pangu'],
     test_suite='test_pangu',
-    entry_points = {
+    entry_points={
         'console_scripts': ['pangu=pangu:main'],
     },
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,10 @@ long_description = open('README.rst').read() + '\n' + open('HISTORY.rst').read()
 setup(
     name='pangu',
     version=get_version(),
-    description='Paranoid text spacing for good readability, to automatically insert whitespace between CJK (Chinese, Japanese, Korean) and half-width characters (alphabetical letters, numerical digits and symbols).',
+    description='Paranoid text spacing for good readability, '
+                'to automatically insert whitespace between CJK '
+                '(Chinese, Japanese, Korean) and half-width characters '
+                '(alphabetical letters, numerical digits and symbols).',
     long_description=long_description,
     keywords='pangu space white text spacing readability',
     author='Vinta Chen',
@@ -46,9 +49,11 @@ setup(
     url='https://github.com/vinta/pangu.py',
     license='MIT',
     include_package_data=True,
-    py_modules=['pangu', ],
-    scripts=['bin/pangu', ],
+    py_modules=['pangu'],
     test_suite='test_pangu',
+    entry_points = {
+        'console_scripts': ['pangu=pangu:main'],
+    },
     zip_safe=False,
     classifiers=(
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # coding: utf-8
 
 import os
-import sys
 import re
 
 from setuptools import setup
@@ -16,18 +15,6 @@ def get_version():
     with open(path) as f:
         return _VERSION_RE.findall(f.read())[-1]
 
-
-if sys.argv[-1] == 'wheel':
-    os.system('make clean')
-    os.system('pip install wheel')
-    os.system('python setup.py bdist_wheel')
-    sys.exit(0)
-
-if sys.argv[-1] == 'publish':
-    os.system('python setup.py wheel')
-    os.system('pip install twine')
-    os.system('twine upload dist/*')
-    sys.exit(0)
 
 setup(
     name='pangu',

--- a/test_pangu.py
+++ b/test_pangu.py
@@ -6,7 +6,6 @@ import pangu
 
 
 class PanguTestCase(unittest.TestCase):
-
     def test_spacing(self):
         self.assertEqual(pangu.spacing('新八的構造成分有95%是眼鏡、3%是水、2%是垃圾'), u'新八的構造成分有 95% 是眼鏡、3% 是水、2% 是垃圾')
         self.assertEqual(pangu.spacing(u'新八的構造成分有95%是眼鏡、3%是水、2%是垃圾'), u'新八的構造成分有 95% 是眼鏡、3% 是水、2% 是垃圾')


### PR DESCRIPTION
This pull request consists of the following changes:
- `.gitignore` is updated.
- `pangu` command is now generated by setuptools using `entry_points` and thus `bin/pangu` is removed.
- `pangu.PanguCLI` is replaced by `pangu.main`.
- Use of `eval()` in  `setup.py` is removed.
  - `eval()` can be used to manipulate program behaviour. For a runtime safe version, see: [ast.literal_eval](https://docs.python.org/3/library/ast.html#ast.literal_eval).
- `publish` and `wheel` commands are moved into `Makefile`.
  - `setup.py` commands should inherit from `distutils.core.Command` and be registered using `entry_points` or `cmdclass`.
  - Preferably, packages can be published by Travis CI.
- `README.rst` is updated to reflect the May PyPI URL change.